### PR TITLE
Update stepper layout to a neutral progress bar

### DIFF
--- a/IMPLEMENTATION_DOCUMENT.md
+++ b/IMPLEMENTATION_DOCUMENT.md
@@ -162,7 +162,7 @@ export interface Summary {
 - **Validações**: gasto mensal obrigatório; tarifas/consumos negativos bloqueados; `aria-live` para mensagens.
 
 ## 9. Acessibilidade & responsividade
-- Stepper com `aria-current`, cartões/inputs navegáveis por teclado.
+- Stepper com `aria-current`, barra de progresso neutra e botões das etapas navegáveis por teclado.
 - SegmentPicker usa radios e descrição textual de β/γ/área/energia.
 - Layout responsivo (mobile-first). Gráfico com altura fixa e overflow horizontal em telas estreitas.
 - Goniômetro possui descrição e controles de teclado (setas) no modo manual.

--- a/IMPLEMENTATION_DOCUMENT.md
+++ b/IMPLEMENTATION_DOCUMENT.md
@@ -73,6 +73,7 @@ src/
 3. **Ângulos** – Valores da Solar API ficam bloqueados (com mensagem informativa). Se manual, sliders 14–22° e 0–360° + goniômetro.
 4. **Conta de luz** – Formulário idêntico ao MVP original (gasto obrigatório, tarifa/consumo opcionais, meta 50–100%).
 5. **Resultados** – Botão “Calcular” roda `useSolarCalc`. Painéis exibem kWp dimensionado, limite por área, geração média/mensal, economia, meta. Gráfico Jan–Dez, tabela com HPOA/Yf/energia/economia/incerteza. Fonte (Solar API vs Manual) fica indicada no cabeçalho e nota explicativa. PDF inclui resumo e fonte.
+6. **Identidade visual** – Componentes compartilham a paleta neutra introduzida no stepper (fundo branco, bordas cinza-claro, tipografia grafite) consolidada em `src/styles/globals.css`.
 
 ### 3.2 Wireframe atualizado
 ```

--- a/UI_COMPONENTS_OVERVIEW.md
+++ b/UI_COMPONENTS_OVERVIEW.md
@@ -112,7 +112,8 @@ O estado global (`AppStateContext`) armazena: endereço (`place`), dados da Sola
 - `isCalculating`: controla botão de cálculo/disable + loader.
 
 ## 10. Observações de UI
-- Layout utiliza util classes CSS em `src/styles/globals.css` (cards, botões, inputs).
+- Layout utiliza util classes CSS em `src/styles/globals.css` (cards, botões, inputs) com paleta neutra (fundo branco, cinzas
+  claros, texto grafite).
 - Responsividade: grids transformam-se em colunas no mobile; imagens/static maps se ajustam ao container.
 - Acessibilidade: `aria-labels`, `visually-hidden` para mensagens, botões com estados e navegação por teclado no stepper.
 

--- a/UI_COMPONENTS_OVERVIEW.md
+++ b/UI_COMPONENTS_OVERVIEW.md
@@ -8,7 +8,8 @@ Este documento descreve a organização das telas do assistente "Economia Solar"
   - Renderiza o `Stepper` com os rótulos das etapas.
   - Filhos: qualquer página (no MVP apenas `HomePage`).
 - **`Stepper` (`src/components/layout/Stepper.tsx`)**
-  - Exibe as etapas definidas em `AppStateContext`. Cada item é um botão.
+  - Mostra uma barra de progresso neutra (fundo branco, borda cinza-claro) e os rótulos das etapas.
+  - Permite retornar a etapas anteriores (botões habilitados até o passo atual) preservando títulos e descrições.
   - Props: `steps` (`StepDefinition[]`). Seleciona etapa via `useAppState().setStep`.
 - **`HomePage` (`src/routes/HomePage.tsx`)**
   - Seleciona dinamicamente o componente de etapa com base em `currentStepIndex`.

--- a/src/components/layout/Stepper.tsx
+++ b/src/components/layout/Stepper.tsx
@@ -11,29 +11,49 @@ export function Stepper({ steps }: StepperProps) {
     setStep,
   } = useAppState()
 
+  const totalSteps = steps.length
+  const maximumStepIndex = Math.max(totalSteps - 1, 1)
+  const progressPercent = (currentStepIndex / maximumStepIndex) * 100
+
   return (
     <nav className="stepper" aria-label="Fluxo principal do assistente">
-      {steps.map((step, index) => {
-        const isActive = index === currentStepIndex
-        const isEnabled = index <= currentStepIndex
+      <div
+        className="stepper-progress"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={totalSteps - 1}
+        aria-valuenow={currentStepIndex}
+        aria-valuetext={`Etapa ${currentStepIndex + 1} de ${totalSteps}`}
+      >
+        <div className="stepper-progress-fill" style={{ width: `${progressPercent}%` }} />
+      </div>
 
-        return (
-          <div className="stepper-item" key={step.key}>
-            <button
-              type="button"
-              onClick={() => isEnabled && setStep(index)}
-              disabled={!isEnabled}
-              aria-current={isActive ? 'step' : undefined}
-            >
-              <span className={`badge ${isActive ? 'badge-active' : ''}`}>{index + 1}</span>
-              <span>
-                <span style={{ display: 'block', fontSize: '0.85rem', opacity: 0.75 }}>{step.title}</span>
-                <span style={{ fontSize: '0.7rem', opacity: 0.6 }}>{step.description}</span>
-              </span>
-            </button>
-          </div>
-        )
-      })}
+      <ol className="stepper-list">
+        {steps.map((step, index) => {
+          const isActive = index === currentStepIndex
+          const isEnabled = index <= currentStepIndex
+          const status = isActive ? 'active' : index < currentStepIndex ? 'complete' : 'upcoming'
+
+          return (
+            <li className={`stepper-item stepper-item-${status}`} key={step.key}>
+              <button
+                type="button"
+                onClick={() => isEnabled && setStep(index)}
+                disabled={!isEnabled}
+                aria-current={isActive ? 'step' : undefined}
+              >
+                <span className="stepper-index" aria-hidden="true">
+                  {index + 1}
+                </span>
+                <span className="stepper-text">
+                  <span className="stepper-title">{step.title}</span>
+                  <span className="stepper-description">{step.description}</span>
+                </span>
+              </button>
+            </li>
+          )
+        })}
+      </ol>
     </nav>
   )
 }

--- a/src/components/maps/GoniometerOverlay.tsx
+++ b/src/components/maps/GoniometerOverlay.tsx
@@ -95,12 +95,12 @@ export function GoniometerOverlay({ azimuthDeg, onAzimuthChange }: GoniometerOve
       <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`}>
         <defs>
           <linearGradient id="goniometerGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#1d4ed8" stopOpacity="0.2" />
-            <stop offset="100%" stopColor="#38bdf8" stopOpacity="0.6" />
+            <stop offset="0%" stopColor="#d1d5db" stopOpacity="0.3" />
+            <stop offset="100%" stopColor="#4b5563" stopOpacity="0.6" />
           </linearGradient>
         </defs>
         <circle cx={SIZE / 2} cy={SIZE / 2} r={SIZE / 2 - 8} fill="url(#goniometerGradient)" stroke="#0f172a" strokeOpacity="0.12" strokeWidth="2" />
-        <circle cx={SIZE / 2} cy={SIZE / 2} r={SIZE / 2 - 36} fill="white" stroke="#cbd5f5" strokeWidth="1" />
+        <circle cx={SIZE / 2} cy={SIZE / 2} r={SIZE / 2 - 36} fill="white" stroke="#d1d5db" strokeWidth="1" />
         <text x={SIZE / 2} y={26} textAnchor="middle" fontSize="12" fill="#0f172a">N</text>
         <text x={SIZE - 24} y={SIZE / 2 + 4} textAnchor="middle" fontSize="12" fill="#0f172a">L</text>
         <text x={SIZE / 2} y={SIZE - 12} textAnchor="middle" fontSize="12" fill="#0f172a">S</text>
@@ -113,7 +113,7 @@ export function GoniometerOverlay({ azimuthDeg, onAzimuthChange }: GoniometerOve
           left: '50%',
           width: 4,
           height: SIZE / 2 - 16,
-          background: 'linear-gradient(180deg, #38bdf8, #2563eb)',
+          background: 'linear-gradient(180deg, #6b7280, #1f2937)',
           transformOrigin: 'center bottom',
           borderRadius: 999,
           pointerEvents: 'none',

--- a/src/components/maps/MapCanvas.tsx
+++ b/src/components/maps/MapCanvas.tsx
@@ -125,11 +125,11 @@ export function MapCanvas({
       const polygon = new google.maps.Polygon({
         map,
         paths: polygonOptions.path,
-        strokeColor: '#2563eb',
+        strokeColor: '#1f2937',
         strokeOpacity: 0.9,
         strokeWeight: 2,
-        fillColor: '#38bdf8',
-        fillOpacity: 0.26,
+        fillColor: '#4b5563',
+        fillOpacity: 0.18,
         draggable: polygonOptions.draggable ?? false,
         editable: polygonOptions.editable ?? false,
       })
@@ -185,11 +185,11 @@ export function MapCanvas({
           drawingModes: [drawingLib.OverlayType.POLYGON],
         },
         polygonOptions: {
-          strokeColor: '#0ea5e9',
+          strokeColor: '#1f2937',
           strokeWeight: 2,
           strokeOpacity: 0.9,
-          fillColor: '#38bdf8',
-          fillOpacity: 0.26,
+          fillColor: '#4b5563',
+          fillOpacity: 0.18,
         },
       })
 

--- a/src/components/maps/StaticThumbnails.tsx
+++ b/src/components/maps/StaticThumbnails.tsx
@@ -43,7 +43,7 @@ export function StaticThumbnails({ center, onSelect, distanceMeters = 60 }: Stat
         url.searchParams.set('scale', '2')
         url.searchParams.set('maptype', 'satellite')
         url.searchParams.set('key', apiKey)
-        url.searchParams.append('markers', `color:0x2563EB|${point.lat},${point.lng}`)
+        url.searchParams.append('markers', `color:0x4B5563|${point.lat},${point.lng}`)
 
         return (
           <button

--- a/src/components/segments/SolarSegmentPicker.tsx
+++ b/src/components/segments/SolarSegmentPicker.tsx
@@ -12,7 +12,7 @@ function buildStaticMapUrl(segment: SolarSegment) {
   url.searchParams.set('scale', '2')
   url.searchParams.set('maptype', 'satellite')
   url.searchParams.set('key', apiKey)
-  url.searchParams.append('markers', `color:0x2563EB|${lat.toFixed(6)},${lng.toFixed(6)}`)
+  url.searchParams.append('markers', `color:0x4B5563|${lat.toFixed(6)},${lng.toFixed(6)}`)
   return url.toString()
 }
 
@@ -55,8 +55,8 @@ export function SolarSegmentPicker({ segments, selectedId, onSelect }: SolarSegm
             htmlFor={`segment-${segment.segmentId}`}
             className="summary-card"
             style={{
-              borderColor: isSelected ? '#2563eb' : undefined,
-              boxShadow: isSelected ? '0 0 0 2px rgba(37, 99, 235, 0.25)' : undefined,
+              borderColor: isSelected ? '#1f2937' : undefined,
+              boxShadow: isSelected ? '0 0 0 2px rgba(17, 24, 39, 0.25)' : undefined,
               cursor: 'pointer',
               display: 'grid',
               gap: '0.65rem',

--- a/src/components/steps/ResultsStep.tsx
+++ b/src/components/steps/ResultsStep.tsx
@@ -17,8 +17,8 @@ function buildStaticMapUrl(points: LatLngPoint[], apiKey: string, centroid: LatL
   const pathPoints = [...points, points[0]]
     .map((point) => `${point.lat.toFixed(6)},${point.lng.toFixed(6)}`)
     .join('|')
-  url.searchParams.append('path', `fillcolor:0x5538BDF8|color:0xFF2563EB|weight:3|${pathPoints}`)
-  url.searchParams.append('markers', `color:0x2563EB|${centroid.lat.toFixed(6)},${centroid.lng.toFixed(6)}`)
+  url.searchParams.append('path', `fillcolor:0x554B5563|color:0xFF1F2937|weight:3|${pathPoints}`)
+  url.searchParams.append('markers', `color:0x1F2937|${centroid.lat.toFixed(6)},${centroid.lng.toFixed(6)}`)
   return url.toString()
 }
 

--- a/src/components/steps/TiltAzimuthStep.tsx
+++ b/src/components/steps/TiltAzimuthStep.tsx
@@ -14,7 +14,7 @@ function buildSegmentStaticMap(segmentCenter?: { lat: number; lng: number }) {
   url.searchParams.set('scale', '2')
   url.searchParams.set('maptype', 'satellite')
   url.searchParams.set('key', apiKey)
-  url.searchParams.append('markers', `color:0x2563EB|label:T|${segmentCenter.lat.toFixed(6)},${segmentCenter.lng.toFixed(6)}`)
+  url.searchParams.append('markers', `color:0x1F2937|label:T|${segmentCenter.lat.toFixed(6)},${segmentCenter.lng.toFixed(6)}`)
   url.searchParams.append('path', `color:0xFFFFFFFF|weight:2|${segmentCenter.lat.toFixed(6)},${segmentCenter.lng.toFixed(6)}`)
   return url.toString()
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -243,56 +243,128 @@ a {
 
 .stepper {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: 1rem;
   padding: 1rem 1.5rem;
-  background: rgba(14, 165, 233, 0.08);
+  background: #ffffff;
   border-radius: 18px;
+  border: 1px solid #e5e7eb;
   margin-bottom: 1.5rem;
 }
 
-.stepper-item {
+.stepper-progress {
+  position: relative;
+  height: 6px;
+  border-radius: 9999px;
+  background: #f3f4f6;
+  overflow: hidden;
+}
+
+.stepper-progress-fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: #1f2937;
+  transition: width 0.3s ease;
+}
+
+.stepper-list {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.stepper-item {
+  flex: 1 1 0;
+  min-width: 200px;
 }
 
 .stepper-item button {
-  border: none;
+  width: 100%;
   background: none;
-  cursor: pointer;
-  font-weight: 600;
-  color: #334155;
+  border: none;
   display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.6rem;
-  border-radius: 12px;
+  gap: 0.75rem;
+  align-items: flex-start;
+  text-align: left;
+  cursor: pointer;
+  padding: 0;
+  color: #111827;
 }
 
-.stepper-item button[aria-current='step'] {
-  background: white;
-  box-shadow: 0 4px 14px rgba(14, 165, 233, 0.25);
-  color: #0f172a;
+.stepper-item button:disabled {
+  cursor: default;
 }
 
-.badge {
+.stepper-item-upcoming button {
+  color: #6b7280;
+}
+
+.stepper-item-active button {
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.stepper-index {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 50%;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  border: 1px solid #d1d5db;
   font-size: 0.9rem;
-  background: rgba(37, 99, 235, 0.12);
-  color: #1d4ed8;
-  font-weight: 700;
+  font-weight: 600;
+  background: #f9fafb;
+  color: inherit;
 }
 
-.badge-active {
-  background: linear-gradient(140deg, #38bdf8, #2563eb);
-  color: white;
+.stepper-item-complete .stepper-index {
+  background: #1f2937;
+  color: #ffffff;
+  border-color: #1f2937;
+}
+
+.stepper-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.stepper-title {
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.stepper-description {
+  font-size: 0.78rem;
+  color: #4b5563;
+}
+
+@media (max-width: 768px) {
+  .stepper {
+    padding: 1rem;
+  }
+
+  .stepper-list {
+    gap: 0.75rem;
+  }
+
+  .stepper-item {
+    min-width: 140px;
+  }
+
+  .stepper-title {
+    font-size: 0.9rem;
+  }
+
+  .stepper-description {
+    font-size: 0.75rem;
+  }
 }
 
 .map-container {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,8 +3,19 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color: #1f2933;
-  background-color: #f6f7fb;
+  --color-background: #f5f6f8;
+  --color-surface: #ffffff;
+  --color-muted-surface: #f3f4f6;
+  --color-border: #e5e7eb;
+  --color-border-subtle: #d1d5db;
+  --color-divider: rgba(15, 23, 42, 0.08);
+  --color-text-primary: #1f2937;
+  --color-text-secondary: #4b5563;
+  --color-text-muted: #6c7280;
+  --shadow-elevated: 0 8px 24px rgba(15, 23, 42, 0.08);
+  --shadow-action: 0 6px 16px rgba(17, 24, 39, 0.18);
+  color: var(--color-text-primary);
+  background-color: var(--color-background);
 }
 
 * {
@@ -14,7 +25,8 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: #f6f7fb;
+  background: var(--color-background);
+  color: var(--color-text-primary);
 }
 
 button {
@@ -50,14 +62,14 @@ a {
   align-items: center;
   gap: 1rem;
   padding: 0.8rem 1.5rem;
-  background: #ffffff;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.1);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-divider);
 }
 
 .navbar-menu {
   border: none;
-  background: rgba(14, 165, 233, 0.12);
-  color: #0f172a;
+  background: var(--color-muted-surface);
+  color: var(--color-text-primary);
   font-size: 1.4rem;
   width: 2.4rem;
   height: 2.4rem;
@@ -73,7 +85,7 @@ a {
 
 .navbar-texts p {
   margin: 0.1rem 0 0;
-  color: #6c7280;
+  color: var(--color-text-muted);
   font-size: 0.85rem;
 }
 
@@ -101,7 +113,7 @@ a {
   bottom: 0;
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(6px);
-  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  border-top: 1px solid var(--color-divider);
   padding: 0.75rem 0;
 }
 
@@ -122,9 +134,9 @@ a {
 }
 
 .bottom-action.primary {
-  background: linear-gradient(120deg, #0ea5e9, #2563eb);
-  color: white;
-  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.25);
+  background: var(--color-text-primary);
+  color: #ffffff;
+  box-shadow: var(--shadow-action);
 }
 
 .bottom-action.primary:disabled {
@@ -134,15 +146,16 @@ a {
 }
 
 .bottom-action.secondary {
-  background: #eef2ff;
-  color: #1e3a8a;
+  background: var(--color-muted-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
 }
 
 .card,
 .section-card {
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: 16px;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  box-shadow: var(--shadow-elevated);
   padding: 1.5rem;
   display: flex;
   flex-direction: column;
@@ -151,7 +164,7 @@ a {
 
 .disclaimer {
   font-size: 0.75rem;
-  color: #94a3b8;
+  color: var(--color-text-muted);
   text-align: center;
   margin: 2rem 0 0;
 }
@@ -174,7 +187,7 @@ a {
 .input-group label {
   font-size: 0.9rem;
   font-weight: 600;
-  color: #384454;
+  color: var(--color-text-secondary);
 }
 
 .input-group input,
@@ -182,15 +195,15 @@ a {
 .input-group textarea {
   padding: 0.6rem 0.75rem;
   border-radius: 10px;
-  border: 1px solid #c7d1e0;
+  border: 1px solid var(--color-border-subtle);
   font-size: 1rem;
   color: inherit;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .input-helper {
   font-size: 0.8rem;
-  color: #6c7789;
+  color: var(--color-text-muted);
 }
 
 .input-helper.error {
@@ -217,9 +230,9 @@ a {
 }
 
 .primary-button {
-  background: linear-gradient(120deg, #0ea5e9, #2563eb);
-  color: white;
-  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.25);
+  background: var(--color-text-primary);
+  color: #ffffff;
+  box-shadow: var(--shadow-action);
 }
 
 .primary-button:disabled {
@@ -233,8 +246,9 @@ a {
 }
 
 .secondary-button {
-  background: #eef2ff;
-  color: #1e3a8a;
+  background: var(--color-muted-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
 }
 
 .secondary-button:hover {
@@ -246,9 +260,9 @@ a {
   flex-direction: column;
   gap: 1rem;
   padding: 1rem 1.5rem;
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: 18px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--color-border);
   margin-bottom: 1.5rem;
 }
 
@@ -293,7 +307,7 @@ a {
   text-align: left;
   cursor: pointer;
   padding: 0;
-  color: #111827;
+  color: var(--color-text-primary);
 }
 
 .stepper-item button:disabled {
@@ -301,11 +315,11 @@ a {
 }
 
 .stepper-item-upcoming button {
-  color: #6b7280;
+  color: var(--color-text-muted);
 }
 
 .stepper-item-active button {
-  color: #1f2937;
+  color: var(--color-text-primary);
   font-weight: 600;
 }
 
@@ -316,17 +330,17 @@ a {
   width: 2rem;
   height: 2rem;
   border-radius: 9999px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border-subtle);
   font-size: 0.9rem;
   font-weight: 600;
-  background: #f9fafb;
+  background: var(--color-muted-surface);
   color: inherit;
 }
 
 .stepper-item-complete .stepper-index {
-  background: #1f2937;
+  background: var(--color-text-primary);
   color: #ffffff;
-  border-color: #1f2937;
+  border-color: var(--color-text-primary);
 }
 
 .stepper-text {
@@ -342,7 +356,7 @@ a {
 
 .stepper-description {
   font-size: 0.78rem;
-  color: #4b5563;
+  color: var(--color-text-secondary);
 }
 
 @media (max-width: 768px) {
@@ -371,7 +385,7 @@ a {
   min-height: 360px;
   border-radius: 16px;
   overflow: hidden;
-  border: 1px solid rgba(30, 64, 175, 0.18);
+  border: 1px solid var(--color-border);
 }
 
 .thumbnail-grid {
@@ -384,7 +398,7 @@ a {
   border-radius: 12px;
   overflow: hidden;
   border: 1px solid rgba(148, 163, 184, 0.4);
-  background: white;
+  background: var(--color-surface);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -392,7 +406,7 @@ a {
 .thumbnail-card:hover,
 .thumbnail-card:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 10px 20px rgba(14, 165, 233, 0.2);
+  box-shadow: 0 10px 20px rgba(17, 24, 39, 0.15);
 }
 
 .thumbnail-card img {
@@ -403,8 +417,9 @@ a {
 .alert {
   padding: 0.85rem 1rem;
   border-radius: 12px;
-  background: rgba(14, 165, 233, 0.12);
-  color: #0f172a;
+  background: var(--color-muted-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
   margin-top: 1rem;
   font-size: 0.9rem;
 }
@@ -425,7 +440,7 @@ a {
   border-radius: 14px;
   padding: 1rem;
   border: 1px solid rgba(148, 163, 184, 0.35);
-  background: white;
+  background: var(--color-surface);
 }
 
 .summary-card strong {
@@ -445,7 +460,7 @@ table {
 }
 
 table thead {
-  background: #eff6ff;
+  background: var(--color-muted-surface);
 }
 
 table th,
@@ -487,15 +502,17 @@ table th,
 .link-button {
   border: none;
   background: none;
-  color: #2563eb;
+  color: var(--color-text-primary);
   font-weight: 600;
   align-self: flex-start;
   cursor: pointer;
   padding: 0;
+  text-decoration: underline;
+  text-decoration-color: rgba(17, 24, 39, 0.35);
 }
 
 .link-button:hover {
-  text-decoration: underline;
+  text-decoration-color: currentColor;
 }
 
 .advanced-panel {
@@ -504,7 +521,7 @@ table th,
   border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 14px;
   padding: 1rem;
-  background: #f8fafc;
+  background: var(--color-muted-surface);
 }
 
 .results-wrapper {
@@ -521,14 +538,14 @@ table th,
 .summary-cards article {
   padding: 1rem;
   border-radius: 14px;
-  background: #f8fbff;
+  background: var(--color-surface);
   border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .summary-cards h3 {
   margin: 0;
   font-size: 0.95rem;
-  color: #475569;
+  color: var(--color-text-secondary);
 }
 
 .summary-cards strong {
@@ -551,11 +568,11 @@ table th,
 
 .static-map figcaption {
   font-size: 0.75rem;
-  color: #6c7280;
+  color: var(--color-text-muted);
 }
 
 .chart-section {
-  background: white;
+  background: var(--color-surface);
   border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.25);
   padding: 1rem;
@@ -568,8 +585,9 @@ table th,
 .loading-block {
   padding: 1rem;
   border-radius: 12px;
-  background: rgba(14, 165, 233, 0.08);
-  color: #0f172a;
+  background: var(--color-muted-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
 }
 
 .modal-backdrop {
@@ -584,7 +602,7 @@ table th,
 }
 
 .modal-container {
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: 18px;
   width: min(760px, 92vw);
   max-height: 90vh;
@@ -671,7 +689,8 @@ table th,
   justify-content: space-between;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  background: rgba(37, 99, 235, 0.08);
+  background: var(--color-muted-surface);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
 }
 


### PR DESCRIPTION
## Summary
- replace the blue stepper pills with a neutral progress bar layout and retain step navigation
- refresh the global stepper styles to use white background, light borders, and dark gray typography
- document the new stepper presentation in the UI overview and implementation notes

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d93bdf54ac8324bfe793e1b066060c